### PR TITLE
Fixes for running as docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM google/golang
-WORKDIR /go/src
-RUN git clone https://github.com/djannot/ecspics.git
+COPY . /go/src/ecspics/
 WORKDIR /go/src/ecspics
-RUN sed -i 's/GOOGLEMAPSAPIKEY/YOURKEY/' /go/src/ecspics/app/templates/index.tmpl
 RUN go get "github.com/cloudfoundry-community/go-cfenv"
 RUN go get "github.com/codegangsta/negroni"
 RUN go get "github.com/gorilla/mux"
 RUN go get "github.com/gorilla/sessions"
 RUN go get "github.com/unrolled/render"
 RUN go build .
+EXPOSE 80
+ENTRYPOINT ["./ecspics"]
+CMD ["-Namespace=ns01","-Hostname=10.10.10.1","-EntryPoint=http://namespaces.ecs-local.local:9020"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN go get "github.com/gorilla/mux"
 RUN go get "github.com/gorilla/sessions"
 RUN go get "github.com/unrolled/render"
 RUN go build .
-EXPOSE 80
+# uncomment to set environment in dockerfile, otherwise use -e flag
+#ENV PORT 80
+#ENV HOSTNAME 10.10.10.1
+#ENV ENDPOINT http://ecs-vip.local.net:9020
+#ENV NAMESPACE ns01
 ENTRYPOINT ["./ecspics"]
-CMD ["-Namespace=ns01","-Hostname=10.10.10.1","-EntryPoint=http://namespaces.ecs-local.local:9020"]

--- a/README.md
+++ b/README.md
@@ -18,24 +18,20 @@ And also a way to show some ECS unique capabilities:
 - The ability to apply retentions to object
 
 You need to create a Base URL with namespace on ECS because the application is using CORS.
+Note that your DNS need to resolve *.<ECS Base URL>.
 
 BUILD
 --------------
 
 The Dockerfile can be used to create a Docker container for this web application.
-
-You need to modify the Dockerfile to indicate your Google Maps API key.
-
-If you don't have a key yet, you can get one at https://developers.google.com/maps/signup
-
-Then, you can build it and run the container.
+Just run thw following command in the folder that contains the Dockerfile: docker build -t ecspics . 
+Please note that you have to correct the Namespace, EndPoint and Hostname either in the Dockerfile or when running the container.
 
 RUN
 --------------
 
-To start the application, run ./ecspics -Namespace=<ECS Namespace> -EndPoint=<ECS endpoint using the Base URL> -Hostname=<ECS IP address>
-
-Note that your DNS need to resolve *.<ECS Base URL>.
+To start the application, run: docker run -d ecspics
+Or if you want to override the settings for Namespace, EndPoint and Hostname: docker run -d ecspics "-Namespace=ns01 -Hostname=10.10.10.1 -EndPoint=http://namespaces.ecs-local.local:9020"
 
 LICENSING
 --------------

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ And also a way to show some ECS unique capabilities:
 - The ability to apply retentions to object
 
 You need to create a Base URL with namespace on ECS because the application is using CORS.
-Note that your DNS need to resolve *.<ECS Base URL>.
+Note that your DNS need to resolve *.\<ECS Base URL\>.
 
 BUILD
 --------------
@@ -37,7 +37,7 @@ docker run -p 8080:80 -e "PORT=80 -e HOSTNAME=10.10.10.1 -e ENDPOINT=http://ecs-
 
 The parameters are the ECS Hostname or IP, the ECS Endpoint (or Loadbalancer) and the Namespace to use.
 
-The application will be available on http://.<ip of application host.>:8080
+The application will be available on http://\<ip of application host\>:8080
 
 LICENSING
 --------------

--- a/README.md
+++ b/README.md
@@ -32,9 +32,12 @@ Please note that you have to correct the Namespace, EndPoint and Hostname either
 RUN
 --------------
 
-To start the application, run: docker run -d ecspics
+To start the application, run: 
+docker run -p 8080:80 -e "PORT=80 -e HOSTNAME=10.10.10.1 -e ENDPOINT=http://ecs-vip.local.net:9020 -e NAMESPACE=ns01 ecspics
 
-Or if you want to override the settings for Namespace, EndPoint and Hostname: docker run -d ecspics "-Namespace=ns01 -Hostname=10.10.10.1 -EndPoint=http://namespaces.ecs-local.local:9020"
+The parameters are the ECS Hostname or IP, the ECS Endpoint (or Loadbalancer) and the Namespace to use.
+
+The application will be available on http://<ip of application host>:8080
 
 LICENSING
 --------------

--- a/README.md
+++ b/README.md
@@ -24,13 +24,16 @@ BUILD
 --------------
 
 The Dockerfile can be used to create a Docker container for this web application.
-Just run thw following command in the folder that contains the Dockerfile: docker build -t ecspics . 
+
+Just run the following command in the folder that contains the Dockerfile: docker build -t ecspics . 
+
 Please note that you have to correct the Namespace, EndPoint and Hostname either in the Dockerfile or when running the container.
 
 RUN
 --------------
 
 To start the application, run: docker run -d ecspics
+
 Or if you want to override the settings for Namespace, EndPoint and Hostname: docker run -d ecspics "-Namespace=ns01 -Hostname=10.10.10.1 -EndPoint=http://namespaces.ecs-local.local:9020"
 
 LICENSING

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ docker run -p 8080:80 -e "PORT=80 -e HOSTNAME=10.10.10.1 -e ENDPOINT=http://ecs-
 
 The parameters are the ECS Hostname or IP, the ECS Endpoint (or Loadbalancer) and the Namespace to use.
 
-The application will be available on http://<ip of application host>:8080
+The application will be available on http://.<ip of application host.>:8080
 
 LICENSING
 --------------

--- a/app/templates/index.tmpl
+++ b/app/templates/index.tmpl
@@ -66,7 +66,7 @@
     </div>
   </div>
   <script
-    src="http://maps.googleapis.com/maps/api/js?key=GOOGLEMAPSAPIKEY">
+    src="http://maps.googleapis.com/maps/api/js">
   </script>
 </body>
 </html>

--- a/ecspics.go
+++ b/ecspics.go
@@ -5,7 +5,6 @@ import (
   "crypto/tls"
   "encoding/json"
   "encoding/xml"
-  "flag"
   "log"
   "net/http"
   "net/url"
@@ -13,7 +12,6 @@ import (
   "strconv"
   "strings"
   "time"
-  cfenv "github.com/cloudfoundry-community/go-cfenv"
   "github.com/codegangsta/negroni"
   "github.com/gorilla/mux"
   "github.com/gorilla/sessions"
@@ -116,27 +114,12 @@ var ecs ECS
 
 func main() {
   var port = ""
-  _, err := cfenv.Current()
-  // If the application isn't running on Cloud Foundry, then get the information from the command line arguments
-  if(err != nil) {
-    port = "80"
-    endPointPtr := flag.String("EndPoint", "", "The Amazon S3 endpoint")
-    namespacePtr := flag.String("Namespace", "", "The ViPR namespace if used in the Object Base URL")
-    hostnamePtr := flag.String("Hostname", "", "The ECS hostname or IP address")
-    flag.Parse()
-    ecs = ECS{
-      Hostname: *hostnamePtr,
-      EndPoint: *endPointPtr,
-      Namespace: *namespacePtr,
-    }
-  // If the application is running on Cloud Founfry, then get the inforlation from environment variables
-  } else {
-    port = os.Getenv("PORT")
-    ecs = ECS{
-      Hostname: os.Getenv("HOSTNAME"),
-      EndPoint: os.Getenv("ENDPOINT"),
-      Namespace: os.Getenv("NAMESPACE"),
-    }
+  // get all the environment data
+  port = os.Getenv("PORT")
+  ecs = ECS{
+    Hostname: os.Getenv("HOSTNAME"),
+    EndPoint: os.Getenv("ENDPOINT"),
+    Namespace: os.Getenv("NAMESPACE"),
   }
 
   hostname, _ = os.Hostname()


### PR DESCRIPTION
Google API keys are no longer needed for JS -> removed
Changed to use only ENV variables (makes it easier with Docker)
Changed to use local repository data instead of remote git repo for Docker build (allows for simple local testing)
